### PR TITLE
demo react memo issue

### DIFF
--- a/test/react-memo/input.tsx
+++ b/test/react-memo/input.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+
+type Props = {
+	Component: React.MemoExoticComponent<any>;
+};
+
+export default function Foo(props: Props) {
+	const { Component } = props;
+	return <Component />;
+}

--- a/test/react-memo/output.js
+++ b/test/react-memo/output.js
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+function Foo(props) {
+	const { Component } = props;
+	return <Component />;
+}
+
+Foo.propTypes = {
+	Component: PropTypes.func.isRequired,
+};
+
+export default Foo;

--- a/test/react-memo/output.json
+++ b/test/react-memo/output.json
@@ -1,0 +1,17 @@
+{
+	"type": "ProgramNode",
+	"body": [
+		{
+			"type": "ComponentNode",
+			"name": "Foo",
+			"types": [
+				{
+					"type": "PropTypeNode",
+					"name": "Component",
+					"propType": { "type": "FunctionNode" },
+					"filenames": {}
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
When setting a property type to `React.MemoExoticComponent<any>` the return parsed PropType is incorrectly defined as `PropTypes.func`.